### PR TITLE
Use relative imports.

### DIFF
--- a/piecewise/plotter.py
+++ b/piecewise/plotter.py
@@ -2,7 +2,7 @@
 import matplotlib.pyplot as plt
 
 # prj
-from regressor import piecewise
+from .regressor import piecewise
 
 
 def plot_data_with_regression(t, v, min_stop_frac=0.03):


### PR DESCRIPTION
* In piecewise/plotter.py the import of the `regressor` (when imported using `from regressor import piecewise`) module does not work since the module resides in the same package as that of `plotter`. This commit changes this statement to use relative imports (`from .regressor import piecewise`).