### PR TITLE
refactoring for performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 *.pyc
 
+# tox and pyenv
+.python-version
+.tox/
+
 # Ignore files generated during `python setup.py install`
 build/
 dist/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package was written to work with both Python 2 and Python 3.
 
 To install this package using setup tools, clone this repo and run `python setup.py install` from within the `piecewise` root directory.
 
-The package's core `piecewise()` function for regression requires only `numpy`. The use of `plot_data_with_regression()` for plotting depends also on `matplotlib`.
+The package's core `piecewise()` function for regression requires only `numpy`. The use of `piecewise_plot()` for plotting depends also on `matplotlib`.
 
 ## Usage
 
@@ -27,7 +27,7 @@ v = np.array(
 Now, you're ready to import the `piecewise()` function and fit a piecewise linear regression.
 
 ```
-from piecewise.regressor import piecewise
+from piecewise import piecewise
 
 model = piecewise(t, v)
 ```
@@ -57,12 +57,16 @@ If you want to interpolate or extrapolate, you can use the `FittedModel`'s `pred
 array([  6.92915647, -96.24799517])
 ```
 
-To see a plot, instead of getting a `FittedModel`, use `plot_data_with_regression()`.
+To see a plot, instead of getting a `FittedModel`, use `piecewise_plot()`.  You may also use an existing `FittedModel`.
 
 ```
-from piecewise.plotter import plot_data_with_regression
+from piecewise import piecewise_plot
 
-plot_data_with_regression(t, v)
+# using an existing FittedModel
+piecewise_plot(t, v, model=model)
+
+# fitting a model on the fly
+piecewise_plot(t, v)
 ```
 
 <img src="/img/example_regression.png" width="400px">

--- a/piecewise/__init__.py
+++ b/piecewise/__init__.py
@@ -1,0 +1,4 @@
+from .regressor import piecewise
+from .plotter import piecewise_plot
+
+__all__ = ['piecewise', 'piecewise_plot']

--- a/piecewise/plotter.py
+++ b/piecewise/plotter.py
@@ -13,7 +13,7 @@ def piecewise_plot(t, v, min_stop_frac=0.03, model=None):
             a merge must account for to be considered "too big" to keep merging;
             the default is usually adequate, but this may be increased to make
             merging more aggressive (leading to fewer segments in the result)
-        model (FittedModel) a previously fit model, if available
+        model (FittedModel): a previously fit model, if available
     Returns:
         None.
     """

--- a/piecewise/plotter.py
+++ b/piecewise/plotter.py
@@ -1,11 +1,8 @@
-# 3p
-import matplotlib.pyplot as plt
-
 # prj
 from .regressor import piecewise
 
 
-def plot_data_with_regression(t, v, min_stop_frac=0.03):
+def piecewise_plot(t, v, min_stop_frac=0.03, model=None):
     """ Fits a piecewise (aka "segmented") regression and creates a scatter plot
     of the data overlaid with the regression segments.
 
@@ -16,10 +13,15 @@ def plot_data_with_regression(t, v, min_stop_frac=0.03):
             a merge must account for to be considered "too big" to keep merging;
             the default is usually adequate, but this may be increased to make
             merging more aggressive (leading to fewer segments in the result)
+        model (FittedModel) a previously fit model, if available
     Returns:
         None.
     """
-    model = piecewise(t, v, min_stop_frac)
+    # 3p
+    # delay importing until first use (enables export in __init__.py)
+    import matplotlib.pyplot as plt
+    
+    model = model or piecewise(t, v, min_stop_frac)
     print('Num segments: %s' % len(model.segments))
     plt.plot(t, v, '.', alpha=0.6)
     for seg in model.segments:
@@ -27,3 +29,6 @@ def plot_data_with_regression(t, v, min_stop_frac=0.03):
         v_hat = [seg.predict(t) for t in t_new]
         plt.plot(t_new, v_hat, 'k-')
     plt.show()
+
+# alias for backward compatibility
+plot_data_with_regression = piecewise_plot

--- a/piecewise/regressor.py
+++ b/piecewise/regressor.py
@@ -27,10 +27,9 @@ def piecewise(t, v, min_stop_frac=0.03):
     t, v = _preprocess(t, v)
 
     # Initialize the segments.
-    init_segments = _get_initial_segments(t, v)
+    init_segments, merges = _get_initial_segments_and_merges(t, v)
     seg_tracker = SegmentTracker(init_segments)
 
-    merges = _get_initial_merges(t, v, seg_tracker.segments)
     # Use a min heap to track potential merges. At the top of the heap
     # will be the next best merge (smallest increase in error).
     heapq.heapify(merges)
@@ -38,7 +37,10 @@ def piecewise(t, v, min_stop_frac=0.03):
     # Greedily make the next best merge until we've merged everything together into
     # one segment.
     cum_cost, biggest_cost_increase = 0.0, 0.0
-    best_segments = seg_tracker.segments
+
+    # list of merges we need to undo to return to last best configuration
+    unnaply_to_best = []
+
     while len(seg_tracker) > 1:
         # Identify the next merge to be executed.
         next_merge = _get_next_merge(merges, seg_tracker)
@@ -54,11 +56,14 @@ def piecewise(t, v, min_stop_frac=0.03):
         biggest_cost_increase = max(biggest_cost_increase, cost_increase)
         if biggest_cost_increase < min_stop_frac*cum_cost or \
                 cost_increase == biggest_cost_increase:
-            best_segments = seg_tracker.segments
+            unnaply_to_best = [next_merge]
+        else:
+            unnaply_to_best.append(next_merge)
 
         # Execute the next merge.
         # Update segments, replacing the two old ones with the one new one.
-        seg_tracker.replace(next_merge.left_seg, next_merge.right_seg, next_merge.new_seg)
+        seg_tracker.apply_merge(next_merge)
+        
         # Add new potential merges.
         neighbors = seg_tracker.get_neighbors(next_merge.new_seg)
         for neighbor in neighbors:
@@ -67,12 +72,15 @@ def piecewise(t, v, min_stop_frac=0.03):
 
     if biggest_cost_increase < min_stop_frac*cum_cost:
         # This path is needed for the case where there is only one segment, because
-        # best_segments isn't updated after merging in the loop above.
-        best_segments = seg_tracker.segments
+        # unnaply_to_best isn't updated after merging in the loop above.
+        unnaply_to_best = []
+    
+    for merge in reversed(unnaply_to_best):
+        seg_tracker.unapply_merge(merge)
 
     fitted_segments = [
         FittedSegment(t[seg.start_index], t[min(seg.end_index, len(t)-1)], seg.coeffs)
-        for seg in best_segments
+        for seg in seg_tracker.segments
     ]
     return FittedModel(fitted_segments)
 
@@ -87,8 +95,8 @@ class FittedSegment(namedtuple('FittedSegment',
         'coeffs'    # (tuple of floats) regression coefficients
     ]
 )):
-    def predict(self, t_new):
-        return _predict(self.coeffs, t_new)
+    def predict(self, t_new, out=None, **ufunc_kwargs):
+        return _predict(self.coeffs, t_new, out=out, **ufunc_kwargs)
 
 
 class FittedModel(object):
@@ -112,13 +120,15 @@ class FittedModel(object):
         Returns:
             np.array of predictions
         """
-        v_hats = np.empty_like(t_new, dtype=float)
-        for idx, t in enumerate(t_new):
-            # Find the applicable segment.
-            seg_index = bisect.bisect_left(self._starts, t) - 1
-            seg = self.segments[max(0, seg_index)]
-            # Use it for prediction
-            v_hats[idx] = seg.predict(t)
+        t_new = np.asanyarray(t_new)
+        if len(self.segments) == 1:
+            return self.segments[0].predict(t_new)
+        
+        seg_index = np.digitize(t_new, [s.end_t for s in self.segments[:-1]])
+        
+        v_hats = np.empty_like(t_new, dtype=np.double)
+        for i, segment in enumerate(self.segments):
+            segment.predict(t_new, out=v_hats, where=seg_index == i)
         return v_hats
 
 
@@ -131,7 +141,8 @@ Segment = namedtuple('Segment',
         'start_index',  # (int) zero-based index of start time
         'end_index',    # (int) zero-based index of non-inclusive end time
         'coeffs',       # (tuple of floats) regression coefficients
-        'error'         # (float) the total error in the segment
+        'error',        # (float) the total error in the segment
+        'cov_data',     # (np.array of floats) incremental covariance data
     ]
 )
 
@@ -154,45 +165,84 @@ class SegmentTracker(object):
     """
 
     def __init__(self, segments):
-        self._ordered_segments = sorted(segments)
-        self._segment_set = set(segments)
+        # Assume segments are sorted
+        starts = np.fromiter((s.start_index for s in segments), np.intp, count=len(segments))
+
+        # One position for each original index.
+        # About 50% of this space is wasted, but this enables O(1) lookup and
+        # replacement by start_index
+        self._segments = np.empty(segments[-1].end_index, dtype=object)
+        self._segments[starts] = segments
+
+        # Valid mask.  As segments are merged, this mask is updated
+        self._valid = np.not_equal(self._segments, None)
+
+        # Previous neighbor lookup
+        self._prev = np.zeros_like(self._segments, dtype=np.intp)
+        self._prev[starts[1:]] = starts[:-1]
+
+        # Cached length.  Without this, we would need to count _valid every len()
+        self._len = len(segments)
 
     def __len__(self):
-        return len(self._ordered_segments)
+        return self._len
 
     def contains(self, segment):
         """ Returns True if segment is currently valid; False otherwise. """
-        return segment in self._segment_set
+        # segment at start_index has not been merged away and is still the same
+        return self._valid[segment.start_index] \
+            and self._segments[segment.start_index] is segment
+    
+    def get_prev(self, segment):
+        """ Returns the left neighbor of segment; None if it is the first. """
+        if segment.start_index > 0:
+            return self._segments[self._prev[segment.start_index]]
+        else:
+            return None
+    
+    def get_next(self, segment):
+        """ Returns the right neighbor of segment; None if it is the last. """
+        if segment.end_index < len(self._segments):
+            return self._segments[segment.end_index]
+        else:
+            return None
 
     def get_neighbors(self, segment):
         """ Returns a list of Segments, containing the 0, 1, or 2 segments
         adjacent to the given Segment.
         """
-        index = bisect.bisect_left(self._ordered_segments, segment)
-        neighbors = []
-        if index - 1 >= 0:
-            neighbors.append(self._ordered_segments[index-1])
-        if index + 1 < len(self._ordered_segments):
-            neighbors.append(self._ordered_segments[index+1])
-        return neighbors
+        return (
+            s for s in (self.get_prev(segment), self.get_next(segment))
+            if s is not None
+        )
 
-    def replace(self, old_left_segment, old_right_segment, new_segment):
+    def apply_merge(self, merge):
         """ Insert a new segment and remove the two existing segments
         from which it was created.
         """
-        # Update the list of Segments.
-        left_index = bisect.bisect_left(self._ordered_segments, old_left_segment)
-        self._ordered_segments[left_index] = new_segment
-        del self._ordered_segments[left_index+1]
-
-        # Update the set of Segments
-        self._segment_set.remove(old_left_segment)
-        self._segment_set.remove(old_right_segment)
-        self._segment_set.add(new_segment)
+        right_seg, new_seg = merge.right_seg, merge.new_seg
+        self._valid[right_seg.start_index] = False
+        _next = self.get_next(right_seg)
+        if _next:
+            self._prev[_next.start_index] = new_seg.start_index
+        self._segments[new_seg.start_index] = new_seg
+        self._len -= 1
+    
+    def unapply_merge(self, merge):
+        """ Remove a segment and reinsert the two segments
+        from which it was created.
+        """
+        right_seg, left_seg = merge.right_seg, merge.left_seg
+        self._valid[right_seg.start_index] = True
+        _next = self.get_next(right_seg)
+        if _next:
+            self._prev[_next.start_index] = right_seg.start_index
+        self._segments[left_seg.start_index] = left_seg
+        self._len += 1
 
     @property
     def segments(self):
-        return tuple(self._ordered_segments)
+        return self._segments[self._valid]
 
 
 ## Helper functions for doing piecewise regression.
@@ -205,7 +255,7 @@ def _preprocess(t, v):
     # Validate the inputs.
     if len(t) != len(v):
         raise ValueError('`t` and `v` must have the same length.')
-    t_arr, v_arr = np.array(t), np.array(v)
+    t_arr, v_arr = np.asanyarray(t, dtype=np.double), np.asanyarray(v, dtype=np.double)
     if not np.all(np.isfinite(t)):
         raise ValueError('All values in `t` must be finite.')
     finite_mask = np.isfinite(v_arr)
@@ -220,7 +270,7 @@ def _preprocess(t, v):
     return t_arr, v_arr
 
 
-def _get_initial_segments(t, v):
+def _get_initial_segments_and_merges(t, v):
     """ Returns a list of Segments. Each Segment is of length 1, 2, or 3. They
     are created by using even-indexed points as seeds and attaching odd-indexed
     points to the neighboring seed with the closer v value.
@@ -235,52 +285,114 @@ def _get_initial_segments(t, v):
     still be suboptimal initializations, as in this case, where the two 1s will
     be initialized in the same segment: [19, 10, 1, 1, -8, -17]
     """
+
+    # creates segments from an array of start, end indices
+    def _init_data(ranges):
+        # number of point in range
+        n = np.diff(ranges, axis=1).reshape(-1)
+        
+        # expand ranges in rows, using masked arrays to deal with uneven lengths.
+        # indices like these:
+        #   [[0, 1], [1, 4], [4, 6]]
+        # yield something like this:
+        #   [
+        #       [v0, --, --],
+        #       [v1, v2, v3],
+        #       [v4, v5, --],
+        #   ]
+        max_n = np.max(n)
+        indices = np.ma.array(ranges[:,:1] + np.arange(max_n).reshape(1, -1))
+        for i in range(1, max_n):
+            indices[n == i, i:] = np.ma.masked
+        
+        segment_t = np.ma.take(t, indices)
+        segment_v = np.ma.take(v, indices)
+    
+        # sum(t), sum(v), unmasked
+        st = np.ma.getdata(np.ma.sum(segment_t, axis=1))
+        sv = np.ma.getdata(np.ma.sum(segment_v, axis=1))
+
+        # mean(t), mean(v)
+        mu_t = (st / n).reshape(-1, 1)
+        mu_v = (sv / n).reshape(-1, 1)
+
+        # distance from means
+        dt = segment_t - mu_t
+        dv = segment_v - mu_v
+
+        # var(t) and cov(t, v), before division by n, unmasked
+        ct = np.ma.getdata(np.ma.sum(dt ** 2, axis=1))
+        ctv = np.ma.getdata(np.ma.sum(dt * dv, axis=1))
+        
+        # slope and intercept
+        # for single point segments (ct == 0), assume slope = 0, intercept = mean(v)
+        slope = np.where(ct > 0, ctv, 0.0)
+        slope = np.divide(slope, ct, out=slope, where = ct > 0).reshape(-1, 1)
+        intercept = mu_v - slope * mu_t
+
+        # sum of squared errors
+        error = np.ma.getdata(
+            np.ma.sum((segment_t * slope + intercept - segment_v) ** 2, axis=1)
+        ).flatten()
+        error[n < 3] = 0.0 # floating point imprecisions
+
+        return [
+            Segment(
+                ranges[i, 0], ranges[i, 1], (intercept[i, 0], slope[i, 0]), error[i],
+                cov_data
+            )
+            for i, cov_data in enumerate(np.c_[n, st, sv, ct, ctv])
+        ]
+    
     # If there are multiple values at the same t, average them and treat them
     # like a single point during initialization. This ensures that all the
     # points with the same t are assigned to the same linear segment.
-    index_ranges, averages = [], []
-    start_index, last_t = 0, t[0]
-    for i in range(1, len(t)):
-        if t[i] != last_t:
-            index_ranges.append((start_index, i))
-            averages.append(np.mean(v[start_index:i]))
-            start_index = i
-            last_t = t[i]
-    index_ranges.append((start_index, i+1))
-    averages.append(np.mean(v[start_index:]))
+    unique_t = np.unique(t, return_index=True)[1]
+    even_n = len(unique_t) % 2 == 0
+    index_ranges = np.c_[unique_t, np.r_[unique_t[1:], len(t)]]
+    
+    # unique t is pretty common, optimize for that
+    averages = v[index_ranges[:,0]]
+    long_ranges = np.diff(index_ranges, axis=1).reshape(-1) > 1
+    if long_ranges.any():
+        averages[long_ranges] = np.fromiter(
+            (v[idx[0]:idx[1]].mean() for idx in index_ranges[long_ranges]),
+            np.double, count=long_ranges.sum()
+        )
 
     # Pair every other t with the t on its left or on its right, based on which
     # is closer.
-    seed_assignments = defaultdict(list)
-    for i in range(1, len(averages), 2):
-        left_diff = abs(averages[i-1] - averages[i])
-        right_diff = abs(averages[i+1] - averages[i]) if len(averages) > i+1 else np.inf
-        best_seed = i-1 if left_diff < right_diff else i+1
-        seed_assignments[best_seed].append(i)
+    pair_left = np.less(*np.abs(
+        np.ediff1d(averages, to_end=np.inf if even_n else None)
+    ).reshape(-1, 2).T)
+    np.copyto(
+        index_ranges[:-1:2, 1],
+        index_ranges[1::2, 1],
+        where=pair_left
+    )
+    np.copyto(
+        index_ranges[2::2, 0],
+        index_ranges[1:-1:2, 0],
+        where=~pair_left[:-1 if even_n else None]
+    )
 
-    # Build the Segment objects.
-    segments = []
-    for i in range(0, len(index_ranges), 2):
-        start_index = min([
-            index_ranges[j][0]
-            for j in seed_assignments[i] + [i]
-        ])
-        end_index = max([
-            index_ranges[j][1]
-            for j in seed_assignments[i] + [i]
-        ])
-        segments.append(_make_segment(t, v, start_index, end_index))
+    # initial segment ranges are at even indices
+    segment_ranges = index_ranges[::2]
+    segments = _init_data(segment_ranges)
 
-    return segments
-
-
-def _get_initial_merges(t, v, segments):
-    """ Returns a list of all possible Merges for the given list of Segments.
-    """
-    return [
-        _make_merge(t, v, segments[i], segments[i+1])
-        for i in range(len(segments)-1)
+    # merge every consecutive segment
+    merge_ranges = np.c_[segment_ranges[:-1,0], segment_ranges[1:,1]]
+    merge_segments = _init_data(merge_ranges)
+    
+    merges = [
+        Merge(
+            new_seg.error - segments[i].error - segments[i + 1].error,
+            segments[i], segments[i + 1], new_seg
+        )
+        for i, new_seg in enumerate(merge_segments)
     ]
+
+    return segments, merges
 
 
 def _get_next_merge(merges, segment_tracker):
@@ -297,35 +409,86 @@ def _get_next_merge(merges, segment_tracker):
             return next_merge
 
 
-def _make_segment(t, v, start_index, end_index):
+def _make_segment(t, v, left_seg, right_seg):
     """ Returns a Segment that starts at start_index and ends at
     the non-inclusive end_index.
     """
-    coeffs, error = _fit_line(t, v, start_index, end_index)
-    return Segment(start_index, end_index, coeffs, error)
+    start_index = left_seg.start_index
+    end_index = right_seg.end_index
+    cov_data = _merge_cov_data(left_seg.cov_data, right_seg.cov_data)
+    coeffs, error = _fit_line(t, v, start_index, end_index, cov_data)
+    return Segment(start_index, end_index, coeffs, error, cov_data)
 
 
 def _make_merge(t, v, left_seg, right_seg):
     """ Returns a Merge combining the left_seg and right_seg Segments.
     """
-    new_seg = _make_segment(t, v, left_seg.start_index, right_seg.end_index)
+    new_seg = _make_segment(t, v, left_seg, right_seg)
     cost = new_seg.error - left_seg.error - right_seg.error
     return Merge(cost, left_seg, right_seg, new_seg)
 
 
-def _fit_line(t, v, start_index, end_index):
+def _merge_cov_data(d1, d2):
+    """ Merge covariance data from two segments into a new one.
+    See also:
+        https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
+        https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online
+    """
+    d3 = d1 + d2
+    n1 = d1[0]
+    n2 = d2[0]
+    n12 = n1 * n2
+    n3 = d3[0]
+    deltat = (d1[1] * n2 - d2[1] * n1) / n12
+    deltav = (d1[2] * n2 - d2[2] * n1) / n12
+    d3[3] += deltat ** 2 * n12 / n3
+    d3[4] += deltat * deltav * n12 / n3
+    return d3
+
+try:
+    # use numexpr, if available, to compute regression error.
+    import numexpr as ne
+
+    _err_expr = ne.NumExpr(
+        'sum((t * slope + intercept - v) ** 2)', (
+            ('t', np.double), ('v', np.double),
+            ('intercept', np.double), ('slope', np.double)
+        )
+    )
+except ImportError:
+    # or do it by hand
+    def _err_expr(t, v, intercept, slope):
+        error = t * slope + intercept - v
+        error **= 2
+        return np.sum(error)
+
+def _fit_line(t, v, start_index, end_index, cov_data):
     """ Fits and OLS regression for the set of t and v values in the given index
     range. Returns (coefficients of line, sum of squared error).
     """
-    t_slice = t[start_index:end_index]
-    v_slice = v[start_index:end_index]
-    A = np.array([np.ones_like(t_slice), t_slice])
-    coeffs, error = np.linalg.lstsq(A.T, v_slice)[0:2]
-    return tuple(coeffs), 0.0 if len(error) == 0 else float(error)
+
+    # based on scipy.stats.linregress
+    mu_t, mu_v = cov_data[1:3] / cov_data[0]
+    ct, ctv  = cov_data[3:]
+    if ct != 0:
+        slope = ctv / ct
+        intercept = mu_v - slope * mu_t
+    else:
+        slope, intercept = 0.0, mu_v
+
+    return (
+        (intercept, slope),
+        _err_expr(t[start_index:end_index], v[start_index:end_index], intercept, slope)
+    )
 
 
-def _predict(coeffs, t):
+def _predict(coeffs, t, out=None, **ufunc_kwargs):
     """ Given OLS coefficients, predict the corresponding v values for the given
     t values.
     """
-    return np.sum(np.array(coeffs) * np.array([1.0, t]))
+    t = np.asanyarray(t)
+    if out is None:
+        out = np.empty_like(t, dtype=np.double)
+    np.multiply(t, coeffs[1], out=out, **ufunc_kwargs)
+    np.add(out, coeffs[0], out=out, **ufunc_kwargs)
+    return out

--- a/tests/test_piecewise.py
+++ b/tests/test_piecewise.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 # prj
-from piecewise.regressor import piecewise
+from piecewise import piecewise
 
 
 class TestPiecewise(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py{27,35,36,37}
+
+[testenv]
+# at least one environment with minimum numpy version, and one without numexpr
+deps =
+    py35: numpy==1.10.0
+    !py35: numpy
+    !py35: numexpr
+    matplotlib
+commands =
+    python -m unittest {posargs:tests.test_piecewise}

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,10 @@
 envlist = py{27,35,36,37}
 
 [testenv]
-# at least one environment with minimum numpy version, and one without numexpr
+# at least one environment with minimum numpy version and without matplotlib
 deps =
     py35: numpy==1.10.0
     !py35: numpy
-    !py35: numexpr
-    matplotlib
+    !py35: matplotlib
 commands =
     python -m unittest {posargs:tests.test_piecewise}


### PR DESCRIPTION
### Intro

This is a lengthy pull request, with lots of changes - sorry for dumping this all at once.  We can review changes together if you'd like.

Current version of piecewise() is quadratic on dataset size, this branch makes it linear:

![cpu_time](https://user-images.githubusercontent.com/1376493/53595208-69968880-3b7b-11e9-86f7-5f8f464ecc93.png)

The trade-off is memory consumption, this branch consumes about 60% more memory for a given dataset size (after discounting overhead):

![rss](https://user-images.githubusercontent.com/1376493/53595340-c2662100-3b7b-11e9-9b1a-5c441c251237.png)

### What has been done

The main change is the replacement of `np.linalg.lstsq` by a manual regression based on covariances (this is the same technique used in `scipy.stats.linregress`.  Data necessary to compute covariance and means of segments can be efficiently merged, which greatly speeds up things.  References:

* [scipy.stats.linregress](https://github.com/scipy/scipy/blob/v1.2.1/scipy/stats/_stats_mstats_common.py#L15-L130)
* [Merging variances](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm)
* [Merging covariances](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online) (the formula I used is close to the end of this section)

In my tests, in all datasets I tried, both implementations returned the same segments.  Differences in regression coefficients were on the order of 1e-10 or less.  Current test cases are all passing.

This change also allowed me to heavily vectorize initialization.

Other performance improvements:

* O(1) operations in `SegmentTracker`
* vectorized `predict()`
* optional speedups if `numexpr` is installed

Other changes:

* made it possible to `from piecewise import piecewise` or `*`
* renamed `plot_data_with_regression` to `piecewise_plot` (kept an alias for backward compatibility)
* added tox support.  all tests are passing on all configurations.

### Benchmark code and results

Code to rerun this test (with included or any other datasets) is available below. Running `benchmark/benchmark` will override current results (stored in `profile_*.txt`, `scale.csv` and `perf.csv`).

[benchmark.zip](https://github.com/DataDog/piecewise/files/2916775/benchmark.zip)

Mean of execution over 10 runs of each configuration:

```
                    cpu_time                               rss                         
version               master performance_improvements   master performance_improvements
dataset environment                                                                    
cpu     py27          30.130                    3.741  65840.4                  91677.2
        py35          35.315                    3.873  66030.0                  87084.8
        py36          29.889                    3.750  67955.2                  91814.8
        py37          30.448                    3.912  68062.8                  91762.8
hockey  py27           0.426                    0.377  26478.0                  27823.6
        py35           0.508                    0.497  26858.4                  25838.4
        py36           0.509                    0.527  28470.0                  30196.0
        py37           0.493                    0.523  28814.4                  30145.2
line    py27           0.468                    0.385  26616.8                  28028.0
        py35           0.542                    0.503  26860.0                  25936.4
        py36           0.530                    0.533  28435.6                  30290.0
        py37           0.533                    0.529  28804.0                  30271.6
steps   py27           0.486                    0.391  26611.6                  28147.6
        py35           0.564                    0.509  26803.6                  25952.0
        py36           0.542                    0.532  28653.6                  30368.4
        py37           0.547                    0.534  28933.2                  30308.4
zigzag  py27           0.461                    0.387  26517.2                  27941.2
        py35           0.533                    0.504  26903.6                  25908.8
        py36           0.525                    0.533  28499.6                  30266.4
        py37           0.527                    0.531  28810.4                  30158.8
```

Top lines of profiling of master version:

```
   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    7.630    7.630   35.045   35.045 regressor_master.py:13(piecewise)
   163940    0.365    0.000   14.698    0.000 regressor_master.py:300(_make_segment)
   163940    1.620    0.000   14.156    0.000 regressor_master.py:316(_fit_line)
   122947    0.306    0.000   12.078    0.000 regressor_master.py:308(_make_merge)
   163940    6.870    0.000   10.834    0.000 linalg.py:2104(lstsq)
    40915    8.764    0.000    8.764    0.000 regressor_master.py:193(segments)
        1    0.373    0.373    4.371    4.371 regressor_master.py:223(_get_initial_segments)
        1    0.000    0.000    3.258    3.258 regressor_master.py:277(_get_initial_merges)
        1    0.035    0.035    3.258    3.258 regressor_master.py:281(<listcomp>)
   163940    0.583    0.000    1.023    0.000 linalg.py:144(_commonType)
   163940    0.182    0.000    0.984    0.000 numeric.py:232(ones_like)
   603423    0.907    0.000    0.907    0.000 {built-in method numpy.array}
    40992    0.229    0.000    0.812    0.000 regressor_master.py:286(_get_next_merge)
    81986    0.116    0.000    0.783    0.000 fromnumeric.py:3014(mean)
    40992    0.439    0.000    0.748    0.000 regressor_master.py:179(replace)
   491820    0.741    0.000    0.741    0.000 {method 'astype' of 'numpy.ndarray' objects}
    81986    0.239    0.000    0.667    0.000 _methods.py:58(_mean)
   163940    0.660    0.000    0.660    0.000 {built-in method _warnings.warn}
   327880    0.302    0.000    0.642    0.000 linalg.py:116(_makearray)
   163941    0.438    0.000    0.438    0.000 {built-in method numpy.copyto}
```

Top lines of profiling of this version:

```
   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.280    0.280    3.896    3.896 regressor.py:13(piecewise)
    81955    0.301    0.000    2.052    0.000 regressor.py:423(_make_merge)
    81955    0.190    0.000    1.651    0.000 regressor.py:412(_make_segment)
    81955    0.994    0.000    0.994    0.000 regressor.py:465(_fit_line)
    40992    0.223    0.000    0.666    0.000 regressor.py:398(_get_next_merge)
    81955    0.405    0.000    0.405    0.000 regressor.py:431(_merge_cov_data)
        1    0.001    0.001    0.327    0.327 regressor.py:273(_get_initial_segments_and_merges)
   122947    0.296    0.000    0.296    0.000 {built-in method _heapq.heappop}
        2    0.005    0.002    0.262    0.131 regressor.py:290(_init_data)
        2    0.108    0.054    0.186    0.093 regressor.py:340(<listcomp>)
   286996    0.179    0.000    0.179    0.000 {built-in method __new__ of type object at 0x564fbcc4af20}
    193/2    0.001    0.000    0.156    0.078 <frozen importlib._bootstrap>:978(_find_and_load)
    193/2    0.001    0.000    0.156    0.078 <frozen importlib._bootstrap>:948(_find_and_load_unlocked)
    185/2    0.001    0.000    0.156    0.078 <frozen importlib._bootstrap>:663(_load_unlocked)
    156/2    0.001    0.000    0.155    0.078 <frozen importlib._bootstrap_external>:722(exec_module)
    265/2    0.000    0.000    0.155    0.078 <frozen importlib._bootstrap>:211(_call_with_frames_removed)
    40992    0.098    0.000    0.153    0.000 regressor.py:219(apply_merge)
   181395    0.147    0.000    0.147    0.000 regressor.py:190(contains)
    40992    0.057    0.000    0.139    0.000 regressor.py:210(get_neighbors)
        1    0.000    0.000    0.131    0.131 __init__.py:106(<module>)
```